### PR TITLE
Load last 24h of archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ version = "0.1.0"
 dependencies = [
  "actix-files",
  "actix-web",
+ "chrono",
  "image",
  "parquet",
  "rstar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ parquet = "55"
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 walkdir = "2"
+chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }


### PR DESCRIPTION
## Summary
- add chrono dependency
- load parquet data timestamps and only keep points from last 24 hours

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f2b67f99c8323b74766eb6d5c1bd2