### PR TITLE
Add date range slider for map data

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -34,6 +34,11 @@
     </style>
   </head>
   <body>
+    <div id="controls" style="position:absolute;top:10px;left:10px;z-index:1000;background:white;padding:4px;border-radius:4px;">
+        Start: <input type="date" id="start"> End: <input type="date" id="end">
+        <button id="apply">Apply</button>
+    </div>
+    <div id="loading" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);z-index:1001;background:white;padding:8px;border-radius:4px;">Loading...</div>
     <div id="map"></div>
     <script>
 
@@ -102,6 +107,16 @@ var toner = L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
 
         // uncomment to add screenshot button
         //L.simpleMapScreenshoter().addTo(map)
+
+        document.getElementById('apply').addEventListener('click', function() {
+            var start = document.getElementById('start').value;
+            var end = document.getElementById('end').value;
+            var loading = document.getElementById('loading');
+            loading.style.display = 'block';
+            fetch('/range?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end))
+                .then(function () { mapdata.redraw(); })
+                .finally(function () { loading.style.display = 'none'; });
+        });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- enable dynamic data loading with new `/range` endpoint
- maintain map data in a mutex-protected `RTree`
- add date input controls and loading indicator in the UI
- fetch data for selected range and redraw tiles

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_684f3130f09c83239cc33a7b1f33eaa5