### PR TITLE
Fix range filtering

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -111,6 +111,12 @@ var toner = L.tileLayer('http://tile.stamen.com/toner/{z}/{x}/{y}.png', {
         document.getElementById('apply').addEventListener('click', function() {
             var start = document.getElementById('start').value;
             var end = document.getElementById('end').value;
+            if (start) {
+                start = start + 'T00:00:00Z';
+            }
+            if (end) {
+                end = end + 'T23:59:59Z';
+            }
             var loading = document.getElementById('loading');
             loading.style.display = 'block';
             fetch('/range?start=' + encodeURIComponent(start) + '&end=' + encodeURIComponent(end))


### PR DESCRIPTION
## Summary
- convert dates to RFC3339 strings on the client before sending
- parse simple `YYYY-MM-DD` dates on the server

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684f34e260888323973063898ead5dfb